### PR TITLE
Adicionando cypress-grep

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # e2e-cypress-best-practices
+
 ## Este projeto tem como objetivo servir como um template de boas práticas em testes e2e com o uso da ferramenta Cypress. Algumas das melhores práticas a serem consideradas são:
 
 - Utilizar seletores que possuem interação com o usuário, como role, label, placeholder, text e display value.Para mais informações acesse o video da conf cypress no link: https://www.youtube.com/watch?v=QR72OPX6YGQ
@@ -7,7 +8,7 @@
 - Utilizar TAGs para organizar e categorizar os testes.
 - Realizar processo de testes em burn para identificar testes flakes.
 - Utilizar TypeScript com o uso de types para garantir a integridade e consistência dos testes.
-- Utilizar a lib test libriry para facilitar a escrita e execução dos testes. Para mais informações acesse o link:  https://testing-library.com/docs/cypress-testing-library/intro/
+- Utilizar a lib test libriry para facilitar a escrita e execução dos testes. Para mais informações acesse o link: https://testing-library.com/docs/cypress-testing-library/intro/
 - Não versionar dados sensíveis no projeto utilizando variáveis de ambiente com cypress.env.
 - Manter a independência entre os testes, garantindo que cada teste possa ser executado de forma isolada.
 - Configurar reports com mocha
@@ -16,8 +17,40 @@
 - Criar comandos customizados para automatizar tarefas comuns, como util, API e sequenses actions.
 
 ## Como executar o projeto
+
 ```bash
 - nvm use
 - npm i
 - npm run open
+```
+
+## Como usar o Cypress Grep para adicionar tags
+
+Estamos adicionando uma tag de smoke como exemplo, para adicionar uma tag
+você pode colocar a tag num bloco it ou em um describe, ao ser inserido no it
+apenas o teste com a tag irá ser executado com a tag, ao colocar no describe todos
+os testes dentro do bloco de describe irão herdar a tag
+
+Para inserir basta fazer algo como o exemplo abaixo:
+
+```
+it("passes", { tags: "@smoke" }, () => { ... }
+```
+
+ou
+
+```
+describe("passes", { tags: "@smoke" }, () => { ... }
+```
+
+E para rodar de forma headless apenas os testes com a tag de smoke utilize:
+
+```
+npx cypress run --env grep=@smoke
+```
+
+Ou com o script que criamos:
+
+```
+npm run cy:run:smoke
 ```

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -3,7 +3,12 @@ const { defineConfig } = require("cypress");
 module.exports = defineConfig({
   e2e: {
     setupNodeEvents(on, config) {
-      // implement node event listeners here
+      require("@cypress/grep/src/plugin")(config);
+      return config;
     },
+  },
+  env: {
+    grepFilterSpecs: true,
+    grepOmitFiltered: true,
   },
 });

--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -1,11 +1,11 @@
 /// <reference types="cypress" />
-describe('template spec', () => {
+describe("template spec", () => {
   beforeEach(() => {
     //cy.exemplePost();
   });
 
-  it('passes', () => {
-    cy.visit('https://example.cypress.io')
+  it("passes", { tags: "@smoke" }, () => {
+    cy.visit("https://example.cypress.io");
     // cy.getByRole("button",'name');
     // cy.getByPlaceholder("Placeholder");
     // cy.getByText("text");
@@ -13,5 +13,5 @@ describe('template spec', () => {
     // cy.getContains("a","text");
     // cy.getByDataTestId("DataTestId");
     // cy.exemple("text");
-  })
+  });
 });

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -1,3 +1,8 @@
 import "./commands/utils";
 import "./commands/actionSequences";
-import "./commands/exempleApi"
+import "./commands/exempleApi";
+// "import" with `@ts-ignore`
+// @see error 2306 https://github.com/microsoft/TypeScript/blob/3fcd1b51a1e6b16d007b368229af03455c7d5794/src/compiler/diagnosticMessages.json#L1635
+// @ts-ignore
+import registerCypressGrep from "@cypress/grep";
+registerCypressGrep();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-  "name": "e2e-cypress-best-practices",
+  "name": "best-pratctices",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "best-pratctices",
       "devDependencies": {
         "@cypress/grep": "^4.0.1",
         "@testing-library/cypress": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "name": "best-pratctices",
   "scripts": {
     "open": "npx cypress open",
-    "headless": "npx cypress run"
-  }, 
+    "headless": "npx cypress run",
+    "cy:run:smoke": "npx cypress run --env grep=@smoke"
+  },
   "devDependencies": {
     "@cypress/grep": "^4.0.1",
     "@testing-library/cypress": "^10.0.1",


### PR DESCRIPTION
Resolvendo issue #3 

## Como usar o Cypress Grep para adicionar tags

Estamos adicionando uma tag de smoke como exemplo, para adicionar uma tag
você pode colocar a tag num bloco it ou em um describe, ao ser inserido no it
apenas o teste com a tag irá ser executado com a tag, ao colocar no describe todos
os testes dentro do bloco de describe irão herdar a tag

Para inserir basta fazer algo como o exemplo abaixo:

```
it("passes", { tags: "@smoke" }, () => { ... }
```

ou

```
describe("passes", { tags: "@smoke" }, () => { ... }
```

E para rodar de forma headless apenas os testes com a tag de smoke utilize:

```
npx cypress run --env grep=@smoke
```

Ou com o script que criamos:

```
npm run cy:run:smoke
```
